### PR TITLE
Adding test for granule subset

### DIFF
--- a/podaac/podaac.py
+++ b/podaac/podaac.py
@@ -16,7 +16,8 @@ import requests
 from future.moves.urllib.parse import urlparse, urlencode
 from future.moves.urllib.request import urlopen
 from future.moves.urllib.error import HTTPError
-import http.client
+from future.moves.http.client import HTTPConnection
+#import http.client
 import os
 import json
 import xml.etree.ElementTree as ET
@@ -483,15 +484,15 @@ class Podaac:
         further used to check the status of the request.
 
         '''
-        input_data = open('input.json', 'r+')
-        input_data = json.load(input_data)
+        data = open(input_file_path, 'r+')
+        input_data = json.load(data)
         input_string = json.dumps(input_data)
 
         # submit subset request
         params = urlencode({'query': input_string})
         headers = {
             "Content-type": "application/x-www-form-urlencoded", "Accept": "*"}
-        conn = http.client.HTTPConnection("podaac.jpl.nasa.gov")
+        conn = HTTPConnection("podaac.jpl.nasa.gov")
         conn.request("POST", "/ws/subset/granule?request=submit",
                      params, headers)
         response = conn.getresponse()

--- a/podaac/podaac.py
+++ b/podaac/podaac.py
@@ -17,7 +17,6 @@ from future.moves.urllib.parse import urlparse, urlencode
 from future.moves.urllib.request import urlopen
 from future.moves.urllib.error import HTTPError
 from future.moves.http.client import HTTPConnection
-#import http.client
 import os
 import json
 import xml.etree.ElementTree as ET

--- a/podaac/tests/podaac_test.py
+++ b/podaac/tests/podaac_test.py
@@ -128,13 +128,14 @@ class test_podaac(unittest.TestCase):
     def test_granule_preview(self):
         dataset_id = 'PODAAC-ASOP2-25X01'
         image_variable = 'wind_speed'
+        path = os.path.dirname(os.path.abspath(__file__))
         image_data = self.podaac.granule_preview(
-            dataset_id=dataset_id, image_variable=image_variable)
+            dataset_id=dataset_id, image_variable=image_variable, path=path)
 
         assert image_data != None
 
         path = os.path.join(os.path.dirname(__file__),
-                            '../' + dataset_id + '.png')
+                            dataset_id + '.png')
         os.remove(path)
         assert_raises(Exception,
                       self.podaac.granule_preview, image_variable='hello')

--- a/podaac/tests/podaac_test.py
+++ b/podaac/tests/podaac_test.py
@@ -77,7 +77,8 @@ class test_podaac(unittest.TestCase):
         assert dataset_id_ == dataset_id
         assert_raises(requests.exceptions.HTTPError, self.podaac.load_last24hours_datacasting_granule_md,
                       'PODAAC-ASOP2-25X01', 'ASCATA-L2-25km', format='iso')
-        assert_raises(Exception, self.podaac.load_last24hours_datacasting_granule_md, short_name='ASCATA-L2-25km', format='iso')
+        assert_raises(Exception, self.podaac.load_last24hours_datacasting_granule_md,
+                      short_name='ASCATA-L2-25km', format='iso')
 
     # test case for the function load_dataset_variables
     def test_dataset_variable(self):
@@ -141,7 +142,14 @@ class test_podaac(unittest.TestCase):
                       self.podaac.granule_preview,
                       dataset_id='PODAAC-ASOP2-25X01', image_variable='hello')
 
-    # test cases for the function subset_status
+    # test case for the function granule_subset
+    def test_granule_subset(self):
+        path = os.path.dirname(os.path.abspath(__file__)) + "/test.json"
+        subset_token = self.podaac.granule_subset(input_file_path=path)
+
+        assert subset_token != ''
+
+    # test case for the function subset_status
     def test_subset_status(self):
         test_status = "unknown"
         token_1 = "a"

--- a/podaac/tests/test.json
+++ b/podaac/tests/test.json
@@ -1,1 +1,12 @@
-{"email":"yournamem@emailaddress.com","query":[{"datasetId":"PODAAC-ASOP2-25X01","granuleIds":["ascat_20160409_113000_metopa_49153_eps_o_250_2401_ovw.l2.nc"],"bbox":"-180,-90,180,90","variables":["wvc_index","model_speed","model_dir","ice_prob","ice_age","wvc_quality_flag","wind_speed","wind_dir","bs_distance","lat","lon","time"],"compact":false}]}
+{
+    "email":"yournamem@emailaddress.com",
+    "query":[
+        {
+            "datasetId":"PODAAC-ASOP2-25X01",
+            "granuleIds":["ascat_20160409_113000_metopa_49153_eps_o_250_2401_ovw.l2.nc"],
+            "bbox":"-180,-90,180,90",
+            "variables":["wvc_index","model_speed","model_dir","ice_prob","ice_age","wvc_quality_flag","wind_speed","wind_dir","bs_distance","lat","lon","time"],
+            "compact":false
+        }
+    ]
+}

--- a/podaac/tests/test.json
+++ b/podaac/tests/test.json
@@ -1,0 +1,1 @@
+{"email":"yournamem@emailaddress.com","query":[{"datasetId":"PODAAC-ASOP2-25X01","granuleIds":["ascat_20160409_113000_metopa_49153_eps_o_250_2401_ovw.l2.nc"],"bbox":"-180,-90,180,90","variables":["wvc_index","model_speed","model_dir","ice_prob","ice_age","wvc_quality_flag","wind_speed","wind_dir","bs_distance","lat","lon","time"],"compact":false}]}


### PR DESCRIPTION
- I have added a very generic test case for now.
- This test case is only to test if the code is compatible with both Python2.x and Python3.x
- I couldn't add a more verbose test case because the granule subset web service returns only a job token which is always generated dynamically, due to this, testing has become difficult for me. 
